### PR TITLE
Added code to handle ERROR status while entering foreground

### DIFF
--- a/Fyber-Cocos2d-iphone/Fyber-Cocos2d-iphone/ads/FyberAdProvider.m
+++ b/Fyber-Cocos2d-iphone/Fyber-Cocos2d-iphone/ads/FyberAdProvider.m
@@ -60,7 +60,7 @@
 
         if (v)
         {
-            if (self.lastStatus == CLOSE_ABORTED || self.lastStatus == CLOSE_FINISHED)
+            if (self.lastStatus == CLOSE_ABORTED || self.lastStatus == CLOSE_FINISHED || self.lastStatus == ERROR)
             {
                 [self completeOffer];
             }


### PR DESCRIPTION
In the FyberAdProvider method:
`-(void)applicationWillEnterForeground:(NSNotification *)n`
.. ERROR event should be handled to make sure app will not freeze when error was reported:

`Fyber-Cocos2d-iphone[2233:280827] [SP Error]: Could not play the video - timeout to start playing reached`